### PR TITLE
Allow dynamic context callbacks for link and form tracking

### DIFF
--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -124,7 +124,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 			var elt = e.target;
 			var type = (elt.nodeName && elt.nodeName.toUpperCase() === 'INPUT') ? elt.type : null;
 			var value = (elt.type === 'checkbox' && !elt.checked) ? null : elt.value;
-			core.trackFormChange(getParentFormName(elt), getFormElementName(elt), elt.nodeName, type, helpers.getCssClasses(elt), value, contextAdder(context));
+			core.trackFormChange(getParentFormName(elt), getFormElementName(elt), elt.nodeName, type, helpers.getCssClasses(elt), value, contextAdder(helpers.resolveDynamicContexts(context, elt, type, value)));
 		};
 	}
 
@@ -135,7 +135,7 @@ object.getFormTrackingManager = function (core, trackerId, contextAdder) {
 		return function (e) {
 			var elt = e.target;
 			var innerElements = getInnerFormElements(elt);
-			core.trackFormSubmission(getFormElementName(elt), helpers.getCssClasses(elt), innerElements, contextAdder(context));
+			core.trackFormSubmission(getFormElementName(elt), helpers.getCssClasses(elt), innerElements, contextAdder(helpers.resolveDynamicContexts(context, elt, innerElements)));
 		};
 	}
 

--- a/src/js/lib/helpers.js
+++ b/src/js/lib/helpers.js
@@ -150,6 +150,28 @@
 		return decodeURIComponent(match[1].replace(/\+/g, ' '));
 	};
 
+	/*
+	 * Find dynamic context generating functions and merge their results into the static contexts
+	 * Combine an array of unchanging contexts with the result of a context-creating function
+	 *
+	 * @param {(object|function(...*): ?object)[]} dynamicOrStaticContexts Array of custom context Objects or custom context generating functions
+	 * @param {...*} Parameters to pass to dynamic callbacks
+	 */
+	object.resolveDynamicContexts = function (dynamicOrStaticContexts) {
+		var params = Array.prototype.slice.call(arguments, 1);
+		return lodash.map(dynamicOrStaticContexts, function(context) {
+			if (typeof context === 'function') {
+				try {
+					return context.apply(null, params);
+				} catch (e) {
+					object.warn('Exception thrown in dynamic context generator: ' + e);
+				}
+			} else {
+				return context;
+			}
+		});
+	};
+
 	/**
 	 * Only log deprecation warnings if they won't cause an error
 	 */

--- a/src/js/links.js
+++ b/src/js/links.js
@@ -97,7 +97,7 @@ object.getLinkTrackingManager = function (core, trackerId, contextAdder) {
 
 				// decodeUrl %xx
 				sourceHref = unescape(sourceHref);
-				core.trackLinkClick(sourceHref, elementId, elementClasses, elementTarget, elementContent, contextAdder(context));
+				core.trackLinkClick(sourceHref, elementId, elementClasses, elementTarget, elementContent, contextAdder(helpers.resolveDynamicContexts(context, sourceElement)));
 			}
 		}
 	}


### PR DESCRIPTION
So this is the change I'll propose to Snowplow.

Rather than updating the link schema this will allow for 'dynamic' contexts in the auto link & form trackers, and these schemas can be shredded out into their own tables and be joined back with the link click event, or to the root pageview event.

So as a simple use case it allows things like:
```javascript
function dataAttributesContext(el) {
    return {
        'schema': 'iglu:com.example.snowplow/web_page/link_data/1-0-0',
        'data': {
            'productId': el.getAttribute('data-product-id'),
            'productCategory': el.getAttribute('data-product-category')
        }
    }
}

snowplow('enableLinkClickTracking', null, true, true, [dataAttributesContext]);
```
so that when you click a link, the contexts are generated for that specific element, rather than being static as is allowed currently.

By specifying different/multiple functions as contexts, we'll use this for Finder to generate a full CSS path to the element from body so we can fully identify which element was clicked.

So more like:
```javascript
function genSelector(el){
    var path = [];

    while (el !== null && !el.isSameNode(document.body)) {
        var level = el.nodeName.toLowerCase();
        if (el.id) level += '#' + el.id;
        if (el.className) level += '.' + el.getAttribute('class').split(/\s+/g).join('.');

        if (!el.id && el.parentNode.childElementCount > 1) {
            level += ':nth-child(' + (Array.prototype.indexOf.call(el.parentNode.children, el) + 1) + ')';
        }

        el = el.parentNode;
        path.push(level);
    }

    return path.reverse().join('>');
}

function finderContext(el) {
    return {'schema': 'iglu:com.finder.snowplow/web_page/element_position/1-0-0',
    'data': {cssPath: genSelector(el)}}
}

snowplow('enableLinkClickTracking', null, true, true, [finderContext]);
```
So this will produce paths like "`div#page>div#main.clearfix>div.content>div#content>div.post-829595.page.type-page.status-publish.hentry:nth-child(2)>div.entry:nth-child(2)>div.ccf.balanceTransferTable.calculator.has-filter-preset:nth-child(7)>form:nth-child(3)>table.t_table.compare-table.cf-table-style.calculator-table.tablesorter.tablesorter-default>tbody:nth-child(3)>tr:nth-child(1)>td.name.sorter-false:nth-child(2)>div.combined-product-info>div.product-link:nth-child(1)>a`" that we can use to identify exact elements (you can copy this path straight into document.querySelector to see the original element) and aggregate clicks into components (think LIKE '%div.ccf.balanceTransferTable%' to get all clicks from all links in that table). We can also use these paths to 'label' elements so that even if the path changes (site redesign) we can still have consistent performance monitoring over time.